### PR TITLE
refactor: 다대다 구조 Relation을 이용해서 구현 / Fix: Foreign Key Constraint Fail…

### DIFF
--- a/data/src/main/java/com/wakeup/data/database/dao/MomentDao.kt
+++ b/data/src/main/java/com/wakeup/data/database/dao/MomentDao.kt
@@ -5,18 +5,22 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import com.wakeup.data.database.entity.GlobeEntity
 import com.wakeup.data.database.entity.MomentEntity
+import com.wakeup.data.database.entity.MomentGlobeEntity
 import com.wakeup.data.database.entity.MomentPictureEntity
+import com.wakeup.data.database.entity.MomentWithGlobesAndPictures
 import com.wakeup.data.database.entity.PictureEntity
 
 @Dao
 interface MomentDao {
 
+    @Transaction
     @Query(
         """
             SELECT * FROM moment
-            WHERE mainAddress LIKE '%' || :query || '%' 
+            WHERE mainAddress LIKE '%' || :query || '%'
             OR detailAddress LIKE '%' || :query || '%'
             OR content LIKE '%' || :query || '%'
             ORDER BY
@@ -24,8 +28,9 @@ interface MomentDao {
             CASE WHEN :sortType = 1 THEN date END ASC
         """
     )
-    fun getMoments(sortType: Int = 0, query: String): PagingSource<Int, MomentEntity>
+    fun getMoments(sortType: Int = 0, query: String): PagingSource<Int, MomentWithGlobesAndPictures>
 
+    @Transaction
     @Query(
         """
             SELECT *, 
@@ -38,26 +43,30 @@ interface MomentDao {
             ORDER BY distance
         """
     )
-    fun getMomentsByNearestDistance(query: String, lat: Double?, lng: Double?): PagingSource<Int, MomentEntity>
+    fun getMomentsByNearestDistance(
+        query: String,
+        lat: Double?,
+        lng: Double?,
+    ): PagingSource<Int, MomentWithGlobesAndPictures>
 
-    @Query(
-        "SELECT * FROM picture WHERE id IN" +
-                "(SELECT picture_id FROM moment_picture WHERE moment_id = :momentId)"
-    )
-    suspend fun getPictures(momentId: Long): List<PictureEntity>
+    @Query("SELECT globe_entity_id FROM globe WHERE name = :globeName")
+    suspend fun getGlobeId(globeName: String): Long
 
-    @Query(
-        "SELECT * FROM globe WHERE id IN " +
-                "(SELECT globe_id FROM moment_globe WHERE moment_id = :momentId)"
-    )
-    suspend fun getGlobes(momentId: Long): List<GlobeEntity>
+    @Query("SELECT picture_entity_id FROM picture WHERE bitmap = :bitmap")
+    suspend fun getPictureByByteArray(bitmap: ByteArray): Long
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun saveMoment(moment: MomentEntity): Long
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun savePicture(picture: List<PictureEntity>): List<Long>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun saveMomentPicture(momentPictures: List<MomentPictureEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun saveGlobes(globes: List<GlobeEntity>): List<Long>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun saveMomentGlobe(momentGlobe: MomentGlobeEntity)
 }

--- a/data/src/main/java/com/wakeup/data/database/dao/MomentDao.kt
+++ b/data/src/main/java/com/wakeup/data/database/dao/MomentDao.kt
@@ -50,10 +50,10 @@ interface MomentDao {
     ): PagingSource<Int, MomentWithGlobesAndPictures>
 
     @Query("SELECT globe_entity_id FROM globe WHERE name = :globeName")
-    suspend fun getGlobeId(globeName: String): Long
+    suspend fun getGlobeIdByName(globeName: String): Long
 
     @Query("SELECT picture_entity_id FROM picture WHERE bitmap = :bitmap")
-    suspend fun getPictureByByteArray(bitmap: ByteArray): Long
+    suspend fun getPictureIdByByteArray(bitmap: ByteArray): Long
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun saveMoment(moment: MomentEntity): Long

--- a/data/src/main/java/com/wakeup/data/database/entity/GlobeEntity.kt
+++ b/data/src/main/java/com/wakeup/data/database/entity/GlobeEntity.kt
@@ -10,6 +10,6 @@ import androidx.room.PrimaryKey
     indices = [Index(value = ["name"], unique = true)]
 )
 data class GlobeEntity(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0L,
+    @PrimaryKey(autoGenerate = true) @ColumnInfo(name = "globe_entity_id") val id: Long = 0L,
     @ColumnInfo(name = "name") val name: String,
 )

--- a/data/src/main/java/com/wakeup/data/database/entity/MomentEntity.kt
+++ b/data/src/main/java/com/wakeup/data/database/entity/MomentEntity.kt
@@ -12,14 +12,14 @@ import androidx.room.PrimaryKey
     foreignKeys = [
         ForeignKey(
             entity = PictureEntity::class,
-            parentColumns = ["id"],
+            parentColumns = ["picture_entity_id"],
             childColumns = ["thumbnail_id"],
-            onDelete = CASCADE
+            onUpdate = CASCADE
         )
     ]
 )
 data class MomentEntity(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0L,
+    @PrimaryKey(autoGenerate = true) @ColumnInfo(name = "moment_entity_id") val id: Long = 0L,
     @Embedded val place: PlaceEntity,
     @ColumnInfo(name = "thumbnail_id") val thumbnailId: Long?,
     @ColumnInfo(name = "content") val content: String,

--- a/data/src/main/java/com/wakeup/data/database/entity/MomentGlobeEntity.kt
+++ b/data/src/main/java/com/wakeup/data/database/entity/MomentGlobeEntity.kt
@@ -3,27 +3,26 @@ package com.wakeup.data.database.entity
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
-import androidx.room.PrimaryKey
 
 @Entity(
     tableName = "moment_globe",
     foreignKeys = [
         ForeignKey(
             entity = MomentEntity::class,
-            parentColumns = ["id"],
-            childColumns = ["moment_id"],
-            onDelete = ForeignKey.CASCADE
+            parentColumns = ["moment_entity_id"],
+            childColumns = ["moment_entity_id"],
+            onUpdate = ForeignKey.CASCADE
         ),
         ForeignKey(
             entity = GlobeEntity::class,
-            parentColumns = ["id"],
-            childColumns = ["globe_id"],
-            onDelete = ForeignKey.CASCADE
+            parentColumns = ["globe_entity_id"],
+            childColumns = ["globe_entity_id"],
+            onUpdate = ForeignKey.CASCADE
         )
-    ]
+    ],
+    primaryKeys = ["moment_entity_id", "globe_entity_id"]
 )
 data class MomentGlobeEntity(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0L,
-    @ColumnInfo(name = "moment_id", index = true) val momentId: Int,
-    @ColumnInfo(name = "globe_id", index = true) val globeId: Int,
+    @ColumnInfo(name = "moment_entity_id", index = true) val momentId: Long,
+    @ColumnInfo(name = "globe_entity_id", index = true) val globeId: Long,
 )

--- a/data/src/main/java/com/wakeup/data/database/entity/MomentPictureEntity.kt
+++ b/data/src/main/java/com/wakeup/data/database/entity/MomentPictureEntity.kt
@@ -3,27 +3,26 @@ package com.wakeup.data.database.entity
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
-import androidx.room.PrimaryKey
 
 @Entity(
     tableName = "moment_picture",
     foreignKeys = [
         ForeignKey(
             entity = MomentEntity::class,
-            parentColumns = ["id"],
-            childColumns = ["moment_id"],
-            onDelete = ForeignKey.CASCADE
+            parentColumns = ["moment_entity_id"],
+            childColumns = ["moment_entity_id"],
+            onUpdate = ForeignKey.CASCADE
         ),
         ForeignKey(
             entity = PictureEntity::class,
-            parentColumns = ["id"],
-            childColumns = ["picture_id"],
-            onDelete = ForeignKey.CASCADE
+            parentColumns = ["picture_entity_id"],
+            childColumns = ["picture_entity_id"],
+            onUpdate = ForeignKey.CASCADE
         )
-    ]
+    ],
+    primaryKeys = ["moment_entity_id", "picture_entity_id"]
 )
 data class MomentPictureEntity(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0L,
-    @ColumnInfo(name = "moment_id", index = true) val momentId: Long,
-    @ColumnInfo(name = "picture_id", index = true) val pictureId: Long,
+    @ColumnInfo(name = "moment_entity_id", index = true) val momentId: Long,
+    @ColumnInfo(name = "picture_entity_id", index = true) val pictureId: Long,
 )

--- a/data/src/main/java/com/wakeup/data/database/entity/MomentWithGlobesAndPictures.kt
+++ b/data/src/main/java/com/wakeup/data/database/entity/MomentWithGlobesAndPictures.kt
@@ -1,0 +1,23 @@
+package com.wakeup.data.database.entity
+
+import androidx.room.Embedded
+import androidx.room.Junction
+import androidx.room.Relation
+
+data class MomentWithGlobesAndPictures(
+    @Embedded val moment: MomentEntity,
+    @Relation(
+        parentColumn = "moment_entity_id",
+        entity = GlobeEntity::class,
+        entityColumn = "globe_entity_id",
+        associateBy = Junction(MomentGlobeEntity::class)
+    )
+    val globeList: List<GlobeEntity>,
+    @Relation(
+        parentColumn = "moment_entity_id",
+        entity = PictureEntity::class,
+        entityColumn = "picture_entity_id",
+        associateBy = Junction(MomentPictureEntity::class)
+    )
+    val pictureList: List<PictureEntity>,
+)

--- a/data/src/main/java/com/wakeup/data/database/entity/PictureEntity.kt
+++ b/data/src/main/java/com/wakeup/data/database/entity/PictureEntity.kt
@@ -10,7 +10,7 @@ import androidx.room.PrimaryKey
     indices = [Index(value = ["bitmap"], unique = true)]
 )
 data class PictureEntity(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0L,
+    @PrimaryKey(autoGenerate = true) @ColumnInfo(name = "picture_entity_id") val id: Long = 0L,
     @ColumnInfo(name = "bitmap") val bitmap: ByteArray,
 ) {
     override fun equals(other: Any?): Boolean {
@@ -30,4 +30,5 @@ data class PictureEntity(
         result = 31 * result + bitmap.contentHashCode()
         return result
     }
+
 }

--- a/data/src/main/java/com/wakeup/data/database/mapper/MomentEntityMapper.kt
+++ b/data/src/main/java/com/wakeup/data/database/mapper/MomentEntityMapper.kt
@@ -2,6 +2,7 @@ package com.wakeup.data.database.mapper
 
 import com.wakeup.data.database.entity.GlobeEntity
 import com.wakeup.data.database.entity.MomentEntity
+import com.wakeup.data.database.entity.MomentWithGlobesAndPictures
 import com.wakeup.data.database.entity.PictureEntity
 import com.wakeup.domain.model.Moment
 import com.wakeup.domain.model.Place
@@ -16,6 +17,18 @@ fun MomentEntity.toDomain(pictures: List<PictureEntity>, globes: List<GlobeEntit
         date = date
     )
 }
+
+fun MomentWithGlobesAndPictures.toDomain(pictures: List<PictureEntity>, globes: List<GlobeEntity>): Moment {
+    return Moment(
+        id = moment.id,
+        place = moment.place.toDomain(),
+        pictures = pictures.map { it.toDomain() },
+        content = moment.content,
+        globes = globes.map { it.toDomain() },
+        date = moment.date
+    )
+}
+
 
 fun Moment.toEntity(place: Place, thumbnailId: Long?): MomentEntity {
     return MomentEntity(

--- a/data/src/main/java/com/wakeup/data/repository/MomentRepositoryImpl.kt
+++ b/data/src/main/java/com/wakeup/data/repository/MomentRepositoryImpl.kt
@@ -2,32 +2,47 @@ package com.wakeup.data.repository
 
 import androidx.paging.PagingData
 import androidx.paging.map
+import com.wakeup.data.database.entity.GlobeEntity
+import com.wakeup.data.database.entity.MomentGlobeEntity
 import com.wakeup.data.database.entity.MomentPictureEntity
 import com.wakeup.data.database.mapper.toDomain
 import com.wakeup.data.database.mapper.toEntity
 import com.wakeup.data.source.local.moment.MomentLocalDataSource
 import com.wakeup.domain.model.Location
 import com.wakeup.domain.model.Moment
-import com.wakeup.domain.model.Place
 import com.wakeup.domain.model.SortType
-import com.wakeup.domain.model.Picture
 import com.wakeup.domain.repository.MomentRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import timber.log.Timber
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class MomentRepositoryImpl @Inject constructor(
     private val localDataSource: MomentLocalDataSource,
 ) : MomentRepository {
 
-    override fun getMoments(sort: SortType, query: String, myLocation: Location?): Flow<PagingData<Moment>> =
+    init {
+        // todo: globe_test_code (must remove to release)
+        CoroutineScope(Dispatchers.IO).launch {
+            localDataSource.saveGlobes(listOf(
+                GlobeEntity(name = "default"),
+                GlobeEntity(name = "globe 1"),
+                GlobeEntity(name = "globe 2"),
+                GlobeEntity(name = "globe 3"))
+            )
+        }
+    }
+
+    override fun getMoments(
+        sort: SortType,
+        query: String,
+        myLocation: Location?,
+    ): Flow<PagingData<Moment>> =
         localDataSource.getMoments(sort, query, myLocation?.toEntity()).map { pagingData ->
-            pagingData.map { momentEntity ->
-                momentEntity.toDomain(
-                    localDataSource.getPictures(momentEntity.id),
-                    localDataSource.getGlobes(momentEntity.id)
-                )
+            pagingData.map { momentInfo ->
+                momentInfo.toDomain(momentInfo.pictureList, momentInfo.globeList)
             }
         }
 
@@ -37,14 +52,19 @@ class MomentRepositoryImpl @Inject constructor(
             return
         } else {
             val pictureIndexes =
-                localDataSource.savePicture(moment.pictures.map { it.toEntity() })
+                localDataSource.savePictures(moment.pictures.map { it.toEntity() })
+            // 정책: moment 추가할 때 항상 globe 하나 선택해서 추가(default 도 하나 선택해서 추가 임).
+            val globeIndex = localDataSource.getGlobeId(moment.globes[0].name)
             val momentIndex =
                 localDataSource.saveMoment(moment.toEntity(moment.place, pictureIndexes[0]))
 
-            localDataSource.saveMomentPicture(
+            localDataSource.saveMomentPictures(
                 pictureIndexes.map { pictureId ->
                     MomentPictureEntity(momentId = momentIndex, pictureId = pictureId)
                 }
+            )
+            localDataSource.saveMomentGlobe(
+                MomentGlobeEntity(momentId = momentIndex, globeId = globeIndex)
             )
         }
     }

--- a/data/src/main/java/com/wakeup/data/source/local/moment/MomentLocalDataSource.kt
+++ b/data/src/main/java/com/wakeup/data/source/local/moment/MomentLocalDataSource.kt
@@ -2,24 +2,32 @@ package com.wakeup.data.source.local.moment
 
 import androidx.paging.PagingData
 import com.wakeup.data.database.entity.GlobeEntity
-import com.wakeup.data.database.entity.MomentEntity
-import com.wakeup.data.database.entity.MomentPictureEntity
-import com.wakeup.data.database.entity.PictureEntity
 import com.wakeup.data.database.entity.LocationEntity
+import com.wakeup.data.database.entity.MomentEntity
+import com.wakeup.data.database.entity.MomentGlobeEntity
+import com.wakeup.data.database.entity.MomentPictureEntity
+import com.wakeup.data.database.entity.MomentWithGlobesAndPictures
+import com.wakeup.data.database.entity.PictureEntity
 import com.wakeup.domain.model.SortType
 import kotlinx.coroutines.flow.Flow
 
 interface MomentLocalDataSource {
 
-    fun getMoments(sortType: SortType, query: String, myLocation: LocationEntity?): Flow<PagingData<MomentEntity>>
+    fun getMoments(sortType: SortType, query: String, myLocation: LocationEntity?): Flow<PagingData<MomentWithGlobesAndPictures>>
 
-    suspend fun getPictures(momentId: Long): List<PictureEntity>
+/*    suspend fun getPictures(momentId: Long): List<PictureEntity>
 
-    suspend fun getGlobes(momentId: Long): List<GlobeEntity>
+    suspend fun getGlobes(momentId: Long): List<GlobeEntity>*/
+
+    suspend fun getGlobeId(globeName: String): Long
 
     suspend fun saveMoment(moment: MomentEntity): Long
 
-    suspend fun savePicture(picture: List<PictureEntity>): List<Long>
+    suspend fun savePictures(pictures: List<PictureEntity>): List<Long>
 
-    suspend fun saveMomentPicture(MomentPictures :List<MomentPictureEntity>)
+    suspend fun saveMomentPictures(momentPictures :List<MomentPictureEntity>)
+
+    suspend fun saveGlobes(globes: List<GlobeEntity>): List<Long>
+
+    suspend fun saveMomentGlobe(momentGlobe :MomentGlobeEntity)
 }

--- a/data/src/main/java/com/wakeup/data/source/local/moment/MomentLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/wakeup/data/source/local/moment/MomentLocalDataSourceImpl.kt
@@ -41,7 +41,7 @@ class MomentLocalDataSourceImpl @Inject constructor(
         ).flow
 
     override suspend fun getGlobeId(globeName: String): Long {
-        return momentDao.getGlobeId(globeName)
+        return momentDao.getGlobeIdByName(globeName)
     }
 
     override suspend fun saveMoment(moment: MomentEntity): Long {
@@ -52,7 +52,7 @@ class MomentLocalDataSourceImpl @Inject constructor(
         val indexResult = momentDao.savePicture(pictures).toMutableList()
         indexResult.forEachIndexed { pictureIndex, id ->
             if (id == EXIST_INSERT_ERROR_CODE) {
-                indexResult[pictureIndex] = momentDao.getPictureByByteArray(pictures[pictureIndex].bitmap)
+                indexResult[pictureIndex] = momentDao.getPictureIdByByteArray(pictures[pictureIndex].bitmap)
             }
         }
         return indexResult.toList()

--- a/presentation/src/main/java/com/wakeup/presentation/ui/addmoment/AddMomentViewModel.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/addmoment/AddMomentViewModel.kt
@@ -2,11 +2,11 @@ package com.wakeup.presentation.ui.addmoment
 
 import android.content.Intent
 import androidx.lifecycle.ViewModel
-import com.wakeup.presentation.model.LocationModel
 import androidx.lifecycle.viewModelScope
 import com.wakeup.domain.usecase.SaveMomentUseCase
 import com.wakeup.presentation.mapper.toDomain
 import com.wakeup.presentation.model.GlobeModel
+import com.wakeup.presentation.model.LocationModel
 import com.wakeup.presentation.model.MomentModel
 import com.wakeup.presentation.model.PictureModel
 import com.wakeup.presentation.model.PlaceModel
@@ -114,7 +114,7 @@ class AddMomentViewModel @Inject constructor(
                     date = selectedDate.value
                 ).toDomain()
             )
-            Timber.d("${pictures.value[0]}")
+            //Timber.d("${pictures.value[0]}")
         }
     }
 }


### PR DESCRIPTION
…ed 에러 해결 (https://github.com/boostcampwm-2022/android06-mogle/issues/52#issue-1461314864)

### 🚀 Issue #5 + #52
- save되는 것의 ```@Insert(onConflict = OnConflictStrategy.REPLACE)``` 로 인해서, [SQLite Foreign Key Constraint Failed (code 787)](https://stackoverflow.com/questions/29341380/sqlite-foreign-key-constraint-failed-code-787) 에러 발생
  -> 해결: ```@Insert(onConflict = OnConflictStrategy.IGNORE)``` 이후, 중복 값이 들어온다면 체크 후, id를 바꿔서 보내주는 형태

### 👨‍🔧 개요
- saveMoments 내용 안정화

### 📝 작업 내용
- [x] MomentDao에 GlobeId, PictureId를 가져오는 쿼리문 함수 추가
- [x] MomentDataSource에 중복 내용에 대한 작업 처리 (Picture 부분)
- [x] 다대다 구조 Relation로 형태 변경
- [x]  saveMoment할 때, globe는 하나를 선택하므로, 하나만 가져오는 로직으로 변경

### 📢 특이 사항
- 각 Entity의 id는 이름이 ~_entity_id 이런식으로 변경되었는데 Relation 변경 작업에서 이것저것 하다보니 생겼습니다. 네이밍 리팩터링 필요해 보여요! 참고 바랍니다

