### PR TITLE
마커 클릭 관련 버그 수정

### DIFF
--- a/presentation/src/main/java/com/wakeup/presentation/ui/home/map/MapFragment.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/home/map/MapFragment.kt
@@ -137,6 +137,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         val clickListener = OnClickListener { marker ->
 
             (marker as Marker).apply {
+                if (mapHelper.isMarkerFocused(marker)) return@OnClickListener true
                 mapHelper.setMarkerFocused(this)
                 mapHelper.moveCamera(naverMap, position)
                 binding.momentModel = (tag as MomentModel)

--- a/presentation/src/main/java/com/wakeup/presentation/ui/home/map/MapHelper.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/home/map/MapHelper.kt
@@ -193,7 +193,7 @@ class MapHelper(context: Context) {
         momentModel.pictures.takeIf { it.isNotEmpty() }?.let {
             markerBinding.ivThumbnail.setImageBitmap(it.first().bitmap)
         } ?: kotlin.run {
-            markerBinding.ivThumbnail.setImageResource(R.drawable.sample_image2)
+            markerBinding.ivThumbnail.setImageResource(R.drawable.ic_no_image)
         }
 
         Marker().apply {

--- a/presentation/src/main/java/com/wakeup/presentation/ui/home/map/MapHelper.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/home/map/MapHelper.kt
@@ -39,6 +39,7 @@ class MapHelper(context: Context) {
      * 현재 포커싱 된 마커 객체
      */
     private var markerFocused: Marker? = null
+    private var zIndexBeforeFocused = 0
 
     /**
      * 지도 생성 함수
@@ -97,6 +98,7 @@ class MapHelper(context: Context) {
         markerFocused = marker
 
         markerFocused?.apply {
+            zIndexBeforeFocused = zIndex
             width += (width * MARKER_SCALE_UP_SIZE).toInt()
             height += (height * MARKER_SCALE_UP_SIZE).toInt()
             zIndex = Z_INDEX_FRONT
@@ -109,11 +111,21 @@ class MapHelper(context: Context) {
      */
     fun setMarkerUnfocused() {
         markerFocused?.apply {
-            width -= (width * MARKER_SCALE_UP_SIZE).toInt()
-            height -= (height * MARKER_SCALE_UP_SIZE).toInt()
-            zIndex = Z_INDEX_BACK
+            width = MARKER_WIDTH.dp.toInt()
+            height = MARKER_HEIGHT.dp.toInt()
+            zIndex = zIndexBeforeFocused
         }
         markerFocused = null
+    }
+
+    /**
+     * 인자로 넘겨진 마커가 현재 포커싱되었는지 확인합니다.
+     *
+     * @param marker 마커 객체
+     * @return true-포커싱 상태
+     */
+    fun isMarkerFocused(marker: Marker): Boolean {
+        return marker === markerFocused
     }
 
     /**
@@ -223,6 +235,8 @@ class MapHelper(context: Context) {
         markerBinding.ivThumbnail.setImageResource(R.drawable.sample_image)
         repeat(10) {
             Marker().apply {
+                width = MARKER_WIDTH.dp.toInt()
+                height = MARKER_HEIGHT.dp.toInt()
                 position = LatLng(37.5670135 + it * 0.00001, 126.9783740)
                 isHideCollidedSymbols = true
                 isIconPerspectiveEnabled = true


### PR DESCRIPTION
### 🚀 Issue #10


### 👨‍🔧 개요
- 마커를 포커싱된 상태에서 계속 클릭하면, 마커가 헐크가 되는 현상을 해결했습니다.
- 마커 포커싱과 해제를 반복하면, 마커가 앤트맨이 되는 현상을 해결했습니다.
- 머지 충돌을 해결하면서, 빠트린 마커 기본 이미지를 다시 추가했습니다.

### 📝 작업 내용
- `MapHelepr`클래스에 포커싱 상태를 판단하는 함수 추가

### 📢 특이 사항
> 집중적으로 봐야하거나, 추가 및 특이 사항
- 없습니다.