### PR TITLE
서로 다른 마커 클릭 관련 버그 수정

### DIFF
--- a/presentation/src/main/java/com/wakeup/presentation/ui/home/map/MapFragment.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/home/map/MapFragment.kt
@@ -138,6 +138,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
 
             (marker as Marker).apply {
                 if (mapHelper.isMarkerFocused(marker)) return@OnClickListener true
+                if (mapHelper.checkFocusedMarkerExists()) mapHelper.setMarkerUnfocused()
                 mapHelper.setMarkerFocused(this)
                 mapHelper.moveCamera(naverMap, position)
                 binding.momentModel = (tag as MomentModel)

--- a/presentation/src/main/java/com/wakeup/presentation/ui/home/map/MapHelper.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/home/map/MapHelper.kt
@@ -129,6 +129,15 @@ class MapHelper(context: Context) {
     }
 
     /**
+     * 현재 포커싱된 마커가 있는지 확인합니다.
+     *
+     * @return true-포커싱된 마커 있음
+     */
+    fun checkFocusedMarkerExists(): Boolean {
+        return markerFocused != null
+    }
+
+    /**
      * 지도에 사용자의 위치 정보를 설정합니다.
      *
      * @param map 지도 객체


### PR DESCRIPTION
### 🚀 Issue #10


### 👨‍🔧 개요
- 서로 다른 마커를 연속적으로 번갈아 클릭하면(지도를 클릭하지 않고 연속으로), 
두 마커가 헐크가 되는 현상을 해결했습니다.

### 📝 작업 내용
- `MapHelper` 클래스에 현재 포커싱된 마커가 있는지 확인하는 함수를 추가했습니다.

### 📢 특이 사항
> 집중적으로 봐야하거나, 추가 및 특이 사항
- 🐛 버그 멈춰주세요... 😅