### PR TITLE
Viewpager Indicator 커스텀 뷰 구현

### DIFF
--- a/presentation/src/main/java/com/wakeup/presentation/customview/textindicator/TextPageIndicator.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/customview/textindicator/TextPageIndicator.kt
@@ -1,0 +1,60 @@
+package com.wakeup.presentation.customview.textindicator
+
+import android.content.Context
+import android.content.res.Resources
+import android.content.res.TypedArray
+import android.graphics.Color
+import android.util.AttributeSet
+import android.util.TypedValue
+import android.view.Gravity
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.lifecycle.LifecycleCoroutineScope
+import androidx.viewpager2.widget.ViewPager2
+import com.wakeup.presentation.R
+
+class TextPageIndicator @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet,
+    defStyleAttr: Int = android.R.attr.textViewStyle,
+) : AppCompatTextView(context, attrs, defStyleAttr) {
+
+    init {
+        getAttrs(attrs)
+    }
+
+    private fun getAttrs(attrs: AttributeSet) {
+        val types = context.obtainStyledAttributes(attrs, R.styleable.TextPageIndicator)
+        setTypedArray(types)
+    }
+
+    private fun setTypedArray(types: TypedArray) {
+        val isDefaultSize =
+            types.getBoolean(R.styleable.TextPageIndicator_defaultIndicatorStyle, false)
+        if (isDefaultSize) setDefaultStyle()
+    }
+
+    private fun setDefaultStyle() {
+        setBackgroundResource(R.drawable.bg_text_indicator)
+        setTextColor(Color.parseColor(WHITE))
+        gravity = Gravity.CENTER
+        width = toDp(DEFAULT_WIDTH)
+        height = toDp(DEFAULT_HEIGHT)
+    }
+
+    fun attachTo(viewPager: ViewPager2, lifecycleCoroutineScope: LifecycleCoroutineScope) {
+        val textViewPagerCallback = TextViewPagerCallback(viewPager, this, lifecycleCoroutineScope)
+        viewPager.registerOnPageChangeCallback(textViewPagerCallback)
+    }
+
+    private fun toDp(value: Int): Int {
+        return Resources.getSystem().displayMetrics?.let { dm ->
+            TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, value.toFloat(), dm)
+        }?.toInt() ?: 0
+    }
+
+    private companion object {
+        const val WHITE = "#FFFFFFFF"
+        const val DEFAULT_WIDTH = 44
+        const val DEFAULT_HEIGHT = 28
+    }
+}

--- a/presentation/src/main/java/com/wakeup/presentation/customview/textindicator/TextViewPagerCallback.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/customview/textindicator/TextViewPagerCallback.kt
@@ -1,4 +1,4 @@
-package com.wakeup.presentation.ui.detail
+package com.wakeup.presentation.customview.textindicator
 
 import android.animation.ObjectAnimator
 import android.widget.TextView

--- a/presentation/src/main/java/com/wakeup/presentation/ui/detail/MomentDetailFragment.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/detail/MomentDetailFragment.kt
@@ -1,6 +1,5 @@
 package com.wakeup.presentation.ui.detail
 
-import android.animation.ObjectAnimator
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -9,29 +8,16 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
-import androidx.viewpager2.widget.ViewPager2.OnPageChangeCallback
-import androidx.viewpager2.widget.ViewPager2.SCROLL_STATE_DRAGGING
-import androidx.viewpager2.widget.ViewPager2.SCROLL_STATE_IDLE
 import com.wakeup.presentation.R
 import com.wakeup.presentation.adapter.DetailPictureAdapter
 import com.wakeup.presentation.databinding.FragmentMomentDetailBinding
 import com.wakeup.presentation.util.setToolbar
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MomentDetailFragment : Fragment() {
     private lateinit var binding: FragmentMomentDetailBinding
     private val args: MomentDetailFragmentArgs by navArgs()
-
-    // TODO 역할 위임
-    private lateinit var indicatorAnimator: ObjectAnimator
-    private val pageChangedFlow = MutableStateFlow(0)
-    private var isDragging = false
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -46,10 +32,8 @@ class MomentDetailFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         initToolbar()
-        initAnimator()
-        initViewPagerAdapter()
         initMoment()
-        collectPageChangedFlow()
+        initViewPagerAdapter()
     }
 
     private fun initToolbar() {
@@ -60,112 +44,23 @@ class MomentDetailFragment : Fragment() {
         )
     }
 
-    private fun initAnimator() {
-        indicatorAnimator =
-            ObjectAnimator.ofFloat(binding.tvIndicator, ALPHA_PROPERTY, START_ALPHA, END_ALPHA)
-                .apply {
-                    duration = FADE_AWAY_DURATION
-                }
+    private fun initMoment() {
+        binding.momentModel = args.momentModel
     }
 
     private fun initViewPagerAdapter() {
         binding.vp2Images.adapter = DetailPictureAdapter()
 
-        binding.vp2Images.registerOnPageChangeCallback(object : OnPageChangeCallback() {
-            var currentPage = 0
-            var infiniteCount = 0
-
-            override fun onPageScrollStateChanged(state: Int) {
-                super.onPageScrollStateChanged(state)
-                when (state) {
-                    SCROLL_STATE_DRAGGING -> isDragging = true
-                    SCROLL_STATE_IDLE -> {
-                        isDragging = false
-                        currentPage = binding.vp2Images.currentItem // 완전히 페이지 변경 되었을 때, 현재 페이지 변경
-
-                        // 완료 데이터 방출
-                        // stateFlow는 이전과 같은 값을 방출하면, collect를 하지 못하여, 계속 값을 증가하여 바꿔줌
-                        // (오버 플로우가 발생해도, 값이 달라지는 거라 괜찮다고 생각)
-                        viewLifecycleOwner.lifecycleScope.launch {
-                            pageChangedFlow.emit(++infiniteCount)
-                        }
-                    }
-                }
-            }
-
-            override fun onPageScrolled(
-                position: Int,
-                positionOffset: Float,
-                positionOffsetPixels: Int,
-            ) {
-                super.onPageScrolled(position, positionOffset, positionOffsetPixels)
-
-                // 화면 반 이상 스크롤 시 다음 페이지로 숫자 변경
-                if (isMoveToRight(currentPage, position)) {
-                    if (positionOffset > HALF) {
-                        showIndicator()
-                        setIndicator(position + OFFSET + 1)
-                    } else setIndicator(position + OFFSET)
-                    return
-                }
-
-                // Move to Left
-                if (positionOffset > HALF) {
-                    setIndicator(position + OFFSET + 1)
-                } else {
-                    showIndicator()
-                    setIndicator(position + OFFSET)
-                }
-            }
-        })
-    }
-
-    private fun isMoveToRight(currentPage: Int, position: Int): Boolean = (currentPage == position)
-
-    private fun showIndicator() {
-        indicatorAnimator.cancel()
-        binding.tvIndicator.alpha = START_ALPHA
-    }
-
-    private fun setIndicator(position: Int) {
-        val totalSize = args.momentModel.pictures.size
-        val res = resources
-        binding.tvIndicator.text = res.getString(R.string.text_indicator, position, totalSize)
-    }
-
-    private fun fadeAwayIndicator() {
-        if (binding.tvIndicator.alpha == END_ALPHA) return
-        indicatorAnimator.start()
-    }
-
-    private fun initMoment() {
-        binding.momentModel = args.momentModel
-    }
-
-    @OptIn(FlowPreview::class)
-    private fun collectPageChangedFlow() {
-        // 페이지를 연속으로 변경하는 경우는 무시
-        // 페이지 변경 후, 일정 시간 동안 가만히 있어야 사라짐
-        viewLifecycleOwner.lifecycleScope.launch {
-            pageChangedFlow.debounce(ANIMATION_START_DELAY).collectLatest {
-                if (!isDragging) fadeAwayIndicator()
-            }
-        }
+        val callback = TextViewPagerCallback(
+            binding.vp2Images,
+            binding.tvIndicator,
+            viewLifecycleOwner.lifecycleScope
+        )
+        binding.vp2Images.registerOnPageChangeCallback(callback)
     }
 
     override fun onDestroyView() {
         binding.unbind()
         super.onDestroyView()
-    }
-
-    private companion object {
-        // 인디케이터 1부터 시작 위함
-        const val ALPHA_PROPERTY = "alpha"
-        const val START_ALPHA = 1.0f
-        const val END_ALPHA = 0.0f
-        const val HALF = 0.5
-        const val OFFSET = 1
-        const val FADE_AWAY_DURATION = 300L
-        const val ANIMATION_START_DELAY = 4000L
     }
 }

--- a/presentation/src/main/java/com/wakeup/presentation/ui/detail/MomentDetailFragment.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/detail/MomentDetailFragment.kt
@@ -50,13 +50,7 @@ class MomentDetailFragment : Fragment() {
 
     private fun initViewPagerAdapter() {
         binding.vp2Images.adapter = DetailPictureAdapter()
-
-        val callback = TextViewPagerCallback(
-            binding.vp2Images,
-            binding.tvIndicator,
-            viewLifecycleOwner.lifecycleScope
-        )
-        binding.vp2Images.registerOnPageChangeCallback(callback)
+        binding.tpiIndicator.attachTo(binding.vp2Images, viewLifecycleOwner.lifecycleScope)
     }
 
     override fun onDestroyView() {

--- a/presentation/src/main/java/com/wakeup/presentation/ui/detail/TextViewPagerCallback.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/detail/TextViewPagerCallback.kt
@@ -1,0 +1,122 @@
+package com.wakeup.presentation.ui.detail
+
+import android.animation.ObjectAnimator
+import android.widget.TextView
+import androidx.lifecycle.LifecycleCoroutineScope
+import androidx.viewpager2.widget.ViewPager2
+import androidx.viewpager2.widget.ViewPager2.OnPageChangeCallback
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.launch
+
+class TextViewPagerCallback(
+    private val viewPager: ViewPager2,
+    private val indicatorView: TextView,
+    private val lifecycleCoroutineScope: LifecycleCoroutineScope,
+) : OnPageChangeCallback() {
+
+    private val totalSize by lazy {
+        viewPager.adapter?.itemCount
+    }
+
+    private val pageChangedFlow = MutableStateFlow(0)
+    private var isDragging = false
+
+    var currentPage = 0
+    var infiniteCount = 0
+
+    private var indicatorAnimator: ObjectAnimator =
+        ObjectAnimator.ofFloat(indicatorView, ALPHA_PROPERTY, START_ALPHA, END_ALPHA)
+            .apply {
+                duration = FADE_AWAY_DURATION
+            }
+
+    init {
+        collectPageChangedFlow()
+    }
+
+    override fun onPageScrollStateChanged(state: Int) {
+        super.onPageScrollStateChanged(state)
+        when (state) {
+            ViewPager2.SCROLL_STATE_DRAGGING -> isDragging = true
+            ViewPager2.SCROLL_STATE_IDLE -> {
+                isDragging = false
+                currentPage = viewPager.currentItem // 완전히 페이지 변경 되었을 때, 현재 페이지 변경
+
+                // 완료 데이터 방출
+                // stateFlow는 이전과 같은 값을 방출하면, collect를 하지 못하여, 계속 값을 증가하여 바꿔줌
+                // (오버 플로우가 발생해도, 값이 달라지는 거라 괜찮다고 생각)
+                lifecycleCoroutineScope.launch {
+                    pageChangedFlow.emit(++infiniteCount)
+                }
+            }
+        }
+    }
+
+    override fun onPageScrolled(
+        position: Int,
+        positionOffset: Float,
+        positionOffsetPixels: Int,
+    ) {
+        super.onPageScrolled(position, positionOffset, positionOffsetPixels)
+
+        // 화면 반 이상 스크롤 시 다음 페이지로 숫자 변경
+        if (isMoveToRight(currentPage, position)) {
+            if (positionOffset > HALF) {
+                fadeInIndicator()
+                setIndicatorText(position + OFFSET + 1)
+            } else {
+                setIndicatorText(position + OFFSET)
+            }
+            return
+        }
+
+        // Move to Left
+        if (positionOffset > HALF) {
+            setIndicatorText(position + OFFSET + 1)
+        } else {
+            fadeInIndicator()
+            setIndicatorText(position + OFFSET)
+        }
+    }
+
+    private fun isMoveToRight(currentPage: Int, position: Int): Boolean = (currentPage == position)
+
+    private fun fadeInIndicator() {
+        indicatorAnimator.cancel()
+        indicatorView.alpha = START_ALPHA
+    }
+
+    private fun fadeAwayIndicator() {
+        if (indicatorView.alpha == END_ALPHA) return
+        indicatorAnimator.start()
+    }
+
+    private fun setIndicatorText(position: Int) {
+        indicatorView.text = TEXT_INDICATOR.format(position, totalSize)
+    }
+
+    @OptIn(FlowPreview::class)
+    private fun collectPageChangedFlow() {
+        // 페이지를 연속으로 변경하는 경우는 무시
+        // 페이지 변경 후, 일정 시간 동안 가만히 있어야 사라짐
+        lifecycleCoroutineScope.launch {
+            pageChangedFlow.debounce(ANIMATION_START_DELAY).collectLatest {
+                if (!isDragging) fadeAwayIndicator()
+            }
+        }
+    }
+
+    private companion object {
+        const val ALPHA_PROPERTY = "alpha"
+        const val START_ALPHA = 1.0f
+        const val END_ALPHA = 0.0f
+        const val HALF = 0.5
+        const val OFFSET = 1 // 인디케이터 1부터 시작 위함
+        const val FADE_AWAY_DURATION = 300L
+        const val ANIMATION_START_DELAY = 4000L
+        const val TEXT_INDICATOR = "%d/%d"
+    }
+}

--- a/presentation/src/main/res/layout/fragment_moment_detail.xml
+++ b/presentation/src/main/res/layout/fragment_moment_detail.xml
@@ -106,16 +106,14 @@
                             android:layout_height="match_parent"
                             android:orientation="horizontal" />
 
-                        <TextView
-                            android:id="@+id/tv_indicator"
-                            android:layout_width="@dimen/normal_275"
-                            android:layout_height="@dimen/normal_175"
+                        <com.wakeup.presentation.customview.textindicator.TextPageIndicator
+                            android:id="@+id/tpi_indicator"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
                             android:layout_gravity="end|top"
                             android:layout_marginTop="@dimen/small_100"
                             android:layout_marginRight="@dimen/small_100"
-                            android:background="@drawable/bg_text_indicator"
-                            android:gravity="center"
-                            android:textColor="@color/white"
+                            app:defaultIndicatorStyle="true"
                             tools:text="1/5" />
                     </FrameLayout>
                 </androidx.cardview.widget.CardView>
@@ -136,11 +134,11 @@
 
                 <TextView
                     android:id="@+id/tv_globe"
+                    globeNames="@{momentModel.globes}"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/large_100"
                     android:layout_marginBottom="@dimen/large_200"
-                    globeNames="@{momentModel.globes}"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toStartOf="@id/tv_date"
                     app:layout_constraintStart_toStartOf="@id/guideline_start"

--- a/presentation/src/main/res/values/attrs.xml
+++ b/presentation/src/main/res/values/attrs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="TextPageIndicator">
+        <attr name="defaultIndicatorStyle" format="boolean" />
+    </declare-styleable>
+</resources>


### PR DESCRIPTION
### 🚀 Issue #15


### 👨‍🔧 개요
- `ViewPager`의 `Indicator`를 커스텀 뷰로 만들었습니다.
- 덕분에, `MomentDetailFragment`의 코드가 깔끔해졌습니다.

### 📝 작업 내용
- `TextPagerIndicator` 커스텀 뷰 구현
- `textViewPagerIndicator.attachTo(viewpager, lifecycleScope)`를 통해 뷰페이저와 인디케이터를 연결할 수 있습니다.

  - `lifecycleScope`이 필요한 이유는, 내부적으로 `StateFlow`와 `Coroutine`을 사용하기 때문입니다. 

### 📢 특이 사항
> 집중적으로 봐야하거나, 추가 및 특이 사항
- 나중에, 라이브러리로 배포해볼 예정