### PR TITLE
상세 페이지 모먼트 수정, 삭제 메뉴 / 몇가지 버그 해결

### DIFF
--- a/presentation/src/main/java/com/wakeup/presentation/adapter/BindingAdapters.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/adapter/BindingAdapters.kt
@@ -12,8 +12,8 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.google.android.material.textfield.MaterialAutoCompleteTextView
 import com.wakeup.presentation.R
-import com.wakeup.presentation.extension.getBitMapFromVectorDrawable
 import com.wakeup.presentation.model.GlobeModel
+import com.wakeup.presentation.model.PictureModel
 import timber.log.Timber
 import java.io.File
 
@@ -27,20 +27,13 @@ fun bindSubmitList(view: RecyclerView, itemList: List<Any>?) {
 
 @BindingAdapter("submitList")
 fun bindSubmitList(view: ViewPager2, itemList: List<Any>?) {
-    // TODO fallback 이미지 vector와 png 같이 쓸건지 고민 - 벡터 변환 함수가 필요해서.
     view.adapter?.let {
-        itemList?.let { itemList ->
-            if (itemList.isEmpty()) {
-                val fallbackBitmap =
-                    getBitMapFromVectorDrawable(view.context, R.drawable.ic_no_image)
-                //(view.adapter as ListAdapter<Any, *>).submitList(listOf(PictureModel(fallbackBitmap)))
-            } else {
-                (view.adapter as ListAdapter<Any, *>).submitList(itemList)
-            }
+        val adapter = (view.adapter as ListAdapter<Any, *>)
+
+        if (itemList != null) {
+            if (itemList.isEmpty()) adapter.submitList(listOf(PictureModel("null")))
+            else adapter.submitList(itemList)
         }
-    } ?: run {
-        val fallbackBitmap = getBitMapFromVectorDrawable(view.context, R.drawable.ic_no_image)
-        //(view.adapter as ListAdapter<Any, *>).submitList(listOf(PictureModel(fallbackBitmap)))
     }
 }
 
@@ -69,13 +62,13 @@ fun bindThumbnailImageFromFile(view: ImageView, filePath: String?) {
 }
 
 fun bindImageFromFile(view: ImageView, filePath: String?, width: Int, height: Int) {
-    Timber.d(filePath)
     val url = "${view.context.filesDir}/" + "images/" + "$filePath"
     Timber.d(url)
     Glide.with(view.context)
         .load(File(url))
+        .placeholder(R.drawable.ic_no_image)
         .fallback(R.drawable.ic_no_image)
-        .timeout(500)
+        .error(R.drawable.ic_no_image)
         .override(width, height)
         .transition(DrawableTransitionOptions.withCrossFade())
         .into(view)
@@ -86,6 +79,7 @@ fun bindImageFromBitmap(view: ImageView, bitmap: Bitmap?) {
     Glide.with(view.context)
         .load(bitmap)
         .fallback(R.drawable.ic_no_image)
+        .error(R.drawable.ic_no_image)
         .transition(DrawableTransitionOptions.withCrossFade())
         .into(view)
 }
@@ -95,6 +89,7 @@ fun bindImageFromUrl(view: ImageView, url: String?) {
     Glide.with(view.context)
         .load(url)
         .fallback(R.drawable.ic_no_image)
+        .error(R.drawable.ic_no_image)
         .transition(DrawableTransitionOptions.withCrossFade())
         .override(200, 200)
         .into(view)

--- a/presentation/src/main/java/com/wakeup/presentation/adapter/BindingAdapters.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/adapter/BindingAdapters.kt
@@ -13,7 +13,6 @@ import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.google.android.material.textfield.MaterialAutoCompleteTextView
 import com.wakeup.presentation.R
 import com.wakeup.presentation.model.GlobeModel
-import com.wakeup.presentation.model.PictureModel
 import timber.log.Timber
 import java.io.File
 
@@ -28,12 +27,7 @@ fun bindSubmitList(view: RecyclerView, itemList: List<Any>?) {
 @BindingAdapter("submitList")
 fun bindSubmitList(view: ViewPager2, itemList: List<Any>?) {
     view.adapter?.let {
-        val adapter = (view.adapter as ListAdapter<Any, *>)
-
-        if (itemList != null) {
-            if (itemList.isEmpty()) adapter.submitList(listOf(PictureModel("null")))
-            else adapter.submitList(itemList)
-        }
+        (view.adapter as ListAdapter<Any, *>).submitList(itemList)
     }
 }
 

--- a/presentation/src/main/java/com/wakeup/presentation/adapter/DetailPictureAdapter.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/adapter/DetailPictureAdapter.kt
@@ -6,17 +6,37 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.wakeup.presentation.databinding.ListItemDetailPictureBinding
+import com.wakeup.presentation.databinding.ListItemDetailPictureEmptyBinding
 import com.wakeup.presentation.model.PictureModel
 
 class DetailPictureAdapter :
-    ListAdapter<PictureModel, DetailPictureAdapter.DetailPictureViewHolder>(DetailPictureDiffUtil) {
+    ListAdapter<PictureModel, RecyclerView.ViewHolder>(DetailPictureDiffUtil) {
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DetailPictureViewHolder {
-        return DetailPictureViewHolder.from(parent)
+    private val pictureType = 0
+    private val emptyType = 1
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return if (viewType == pictureType) {
+            DetailPictureViewHolder.from(parent)
+        } else {
+            EmptyViewHolder.from(parent)
+        }
     }
 
-    override fun onBindViewHolder(holder: DetailPictureViewHolder, position: Int) {
-        holder.bind(getItem(position))
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        if (holder is DetailPictureViewHolder) {
+            holder.bind(getItem(position))
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return if (currentList.isEmpty()) emptyType else pictureType
+    }
+
+    // ItemCount가 0이면 onCreateViewHolder()가 호출되지 않아, EmptyViewHolder가 생성되지 않습니다.
+    // 따라서, 리스트가 비어있어도 아이템이 1개 있는 것처럼 처리합니다.
+    override fun getItemCount(): Int {
+        return if (currentList.isEmpty()) 1 else currentList.size
     }
 
     class DetailPictureViewHolder private constructor(private val binding: ListItemDetailPictureBinding) :
@@ -36,6 +56,19 @@ class DetailPictureAdapter :
             }
         }
     }
+
+    class EmptyViewHolder private constructor(binding: ListItemDetailPictureEmptyBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        companion object {
+            fun from(parent: ViewGroup): EmptyViewHolder {
+                return EmptyViewHolder(
+                    ListItemDetailPictureEmptyBinding
+                        .inflate(LayoutInflater.from(parent.context), parent, false)
+                )
+            }
+        }
+    }
+
 
     companion object DetailPictureDiffUtil : DiffUtil.ItemCallback<PictureModel>() {
         override fun areItemsTheSame(oldItem: PictureModel, newItem: PictureModel): Boolean {

--- a/presentation/src/main/java/com/wakeup/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/MainActivity.kt
@@ -102,7 +102,7 @@ class MainActivity : AppCompatActivity() {
     private fun setTopLevelDestinations(navController: NavController) {
         val appBarConfiguration = AppBarConfiguration(
             setOf(
-                R.id.map_fragment,
+                R.id.home_fragment,
                 R.id.globe_fragment
             )
         )

--- a/presentation/src/main/java/com/wakeup/presentation/ui/detail/MomentDetailFragment.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/detail/MomentDetailFragment.kt
@@ -42,6 +42,25 @@ class MomentDetailFragment : Fragment() {
             titleId = R.string.moment,
             onBackClick = { findNavController().navigateUp() }
         )
+
+        binding.tbDetailMoment.tbDefault.apply {
+            inflateMenu(R.menu.menu_moment_detail_toolbar)
+            setOnMenuItemClickListener { menu ->
+                when (menu.itemId) {
+                    R.id.item_moment_update -> {
+                        // TODO 모먼트 수정하기
+                        true
+                    }
+
+                    R.id.item_moment_delete -> {
+                        // TODO 모먼트 삭제하기
+                        true
+                    }
+
+                    else -> false
+                }
+            }
+        }
     }
 
     private fun initMoment() {

--- a/presentation/src/main/java/com/wakeup/presentation/ui/home/HomeFragment.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/home/HomeFragment.kt
@@ -1,11 +1,11 @@
 package com.wakeup.presentation.ui.home
 
+import android.Manifest
+import android.annotation.SuppressLint
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.Manifest
-import android.annotation.SuppressLint
 import android.content.pm.PackageManager
 import android.location.Location
 import android.os.Bundle

--- a/presentation/src/main/java/com/wakeup/presentation/ui/home/map/MapFragment.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/home/map/MapFragment.kt
@@ -113,7 +113,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
                     mapHelper.resetMarkers(currentMarkers)
                     currentMarkers.clear()
                     moments.forEach { momentModel ->
-                        setMarkerClickListener(momentModel)
+                        initMarker(momentModel)
                     }
                 }
             }
@@ -136,7 +136,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
          } */
     }
 
-    private fun setMarkerClickListener(moment: MomentModel) {
+    private fun initMarker(moment: MomentModel) {
         val clickListener = OnClickListener { marker ->
 
             (marker as Marker).apply {

--- a/presentation/src/main/java/com/wakeup/presentation/ui/home/map/MapFragment.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/home/map/MapFragment.kt
@@ -144,14 +144,14 @@ class MapFragment : Fragment(), OnMapReadyCallback {
                 binding.momentModel = (tag as MomentModel)
             }
 
-            binding.momentPreview.root.let {
-                it.isVisible = true
-                it.getFadeInAnimator(MOMENT_PREVIEW_ANIM_DURATION).start()
+            binding.momentPreview.root.apply {
+                isVisible = true
+                getFadeInAnimator(MOMENT_PREVIEW_ANIM_DURATION).start()
             }
             true
         }
 
-        mapHelper.setMarker(naverMap, moment, clickListener)
+        mapHelper.setMomentMarker(naverMap, moment, clickListener)
     }
 
     // Deprecated 되었지만,

--- a/presentation/src/main/java/com/wakeup/presentation/ui/home/map/MapFragment.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/home/map/MapFragment.kt
@@ -25,7 +25,6 @@ import com.wakeup.presentation.ui.home.HomeFragmentDirections
 import com.wakeup.presentation.ui.home.HomeViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 class MapFragment : Fragment(), OnMapReadyCallback {
 
@@ -36,7 +35,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
     private lateinit var locationSource: FusedLocationSource
     private lateinit var mapHelper: MapHelper
 
-    private val markers = mutableListOf<Marker>()
+    private val currentMarkers = mutableListOf<Marker>()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -108,12 +107,11 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         }
 
         // 전체 모먼트 불러오기
-        // TODO 속도가 엄청 느려진다.
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.allMoments.collectLatest { moments ->
-                    mapHelper.resetMarker(markers)
-                    markers.clear()
+                    mapHelper.resetMarkers(currentMarkers)
+                    currentMarkers.clear()
                     moments.forEach { momentModel ->
                         setMarkerClickListener(momentModel)
                     }
@@ -156,8 +154,10 @@ class MapFragment : Fragment(), OnMapReadyCallback {
             true
         }
 
-        val marker = mapHelper.setMomentMarker(naverMap, moment, clickListener)
-        markers.add(marker)
+        mapHelper.setMomentMarker(naverMap, moment, clickListener) { marker ->
+            // 현재 지도에 추가된 마커 관리
+            currentMarkers.add(marker)
+        }
     }
 
     // Deprecated 되었지만,

--- a/presentation/src/main/res/layout/fragment_moment_detail.xml
+++ b/presentation/src/main/res/layout/fragment_moment_detail.xml
@@ -101,7 +101,7 @@
 
                         <androidx.viewpager2.widget.ViewPager2
                             android:id="@+id/vp2_images"
-                            submitList="@{momentModel.pictures}"
+                            app:submitList="@{momentModel.pictures}"
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"
                             android:orientation="horizontal" />

--- a/presentation/src/main/res/layout/list_item_detail_picture.xml
+++ b/presentation/src/main/res/layout/list_item_detail_picture.xml
@@ -15,5 +15,5 @@
         android:layout_height="match_parent"
         app:contentImageFromFilePath="@{pictureModel.path}"
         android:scaleType="centerCrop"
-        tools:src="@drawable/sample_image" />
+        tools:src="@drawable/ic_no_image" />
 </layout>

--- a/presentation/src/main/res/layout/list_item_detail_picture_empty.xml
+++ b/presentation/src/main/res/layout/list_item_detail_picture_empty.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <data>
+
+        <variable
+            name="pictureModel"
+            type="com.wakeup.presentation.model.PictureModel" />
+    </data>
+
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scaleType="centerCrop"
+        android:src="@drawable/ic_no_image" />
+</layout>

--- a/presentation/src/main/res/menu/menu_bottom_nav.xml
+++ b/presentation/src/main/res/menu/menu_bottom_nav.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/map_fragment"
+        android:id="@+id/home_fragment"
         android:icon="@drawable/ic_home"
         android:title="@string/home" />
 

--- a/presentation/src/main/res/menu/menu_moment_detail_toolbar.xml
+++ b/presentation/src/main/res/menu/menu_moment_detail_toolbar.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/item_moment_update"
+        android:title="@string/moment_detail_menu_update_moment" />
+    <item
+        android:id="@+id/item_moment_delete"
+        android:title="@string/moment_detail_menu_delete_moment" />
+</menu>

--- a/presentation/src/main/res/navigation/nav_graph.xml
+++ b/presentation/src/main/res/navigation/nav_graph.xml
@@ -3,13 +3,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/map_fragment">
+    app:startDestination="@id/home_fragment">
 
     <fragment
-        android:id="@+id/map_fragment"
+        android:id="@+id/home_fragment"
         android:name="com.wakeup.presentation.ui.home.HomeFragment"
         android:label="지도"
-        tools:layout="@layout/fragment_map">
+        tools:layout="@layout/fragment_home">
         <action
             android:id="@+id/action_map_fragment_to_moment_detail_fragment"
             app:destination="@id/moment_detail_fragment"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -49,6 +49,9 @@
     <string name="globe_detail_menu_update_globe">글로브 이름 수정하기</string>
     <string name="globe_detail_menu_delete_globe">글로브 삭제하기</string>
 
+    <string name="moment_detail_menu_update_moment">모먼트 수정하기</string>
+    <string name="moment_detail_menu_delete_moment">모먼트 삭제하기</string>
+
     <string name="snack_bar_message_add_globe">글로브가 생성되었습니다</string>
 
     <string name="temperature_celsius">%.1f°C</string>


### PR DESCRIPTION
### 🚀 Issue #15, #10


### 👨‍🔧 개요
- 상세 페이지에 모먼트 수정, 삭제 메뉴를 추가했습니다.
- 모먼트 추가시, 지도에 마커 이미지가 바로 뜨지 않는 현상을 해결했습니다.
- 상세 페이지의 기본 이미지가 뜨지 않는 현상을 해결했습니다. 

### 📝 작업 내용
- `menu` 추가
- `Glide`에 `error()`, `placeholder()`  추가
- `ViewPager`의 `submitList` 바인딩 어댑터 함수 수정 

### 📢 특이 사항
> 집중적으로 봐야하거나, 추가 및 특이 사항

- `bindImageFromFile()` 함수 내부에서 반드시 `url` 스트링 값을 지정해주고 있어서, `filePath`가 `null`임에도 `url` 값이 존재함 

-> `Glide`의 `fallback()`이 동작하지 않음 -> 따라서, `error()`를 추가했습니다.