### PR TITLE
장소 이미지 크롤링 제거, 홈화면 StatusBar 투명 처리, FAB 변화 버그 해결, 홈 -> 글로브 UI 튀는 버그 해결, FAB 아래 터치 버그 해결

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,4 +1,5 @@
 <resources>
+
     <style name="Theme.Mogle" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="colorPrimary">@color/mint</item>
         <item name="colorOnPrimary">@color/white</item>
@@ -16,5 +17,6 @@
         <item name="android:textColorSecondary">@color/light_gray</item>
 
         <item name="android:statusBarColor">?android:colorBackground</item>
+        <item name="android:windowLightStatusBar">false</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,5 @@
 <resources>
+
     <style name="Theme.Mogle" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="colorPrimary">@color/mint</item>
         <item name="colorOnPrimary">@color/white</item>

--- a/data/src/main/java/com/wakeup/data/di/DataSourceModule.kt
+++ b/data/src/main/java/com/wakeup/data/di/DataSourceModule.kt
@@ -8,6 +8,8 @@ import com.wakeup.data.source.local.picture.PictureLocalDataSource
 import com.wakeup.data.source.local.picture.PictureLocalDataSourceImpl
 import com.wakeup.data.source.local.xref.XRefLocalDataSource
 import com.wakeup.data.source.local.xref.XRefLocalDataSourceImpl
+import com.wakeup.data.source.remote.imageSearch.ImageSearchRemoteDataSource
+import com.wakeup.data.source.remote.imageSearch.ImageSearchRemoteDataSourceImpl
 import com.wakeup.data.source.remote.placeSearch.PlaceSearchRemoteDataSource
 import com.wakeup.data.source.remote.placeSearch.PlaceSearchRemoteDataSourceImpl
 import com.wakeup.data.source.remote.weather.WeatherRemoteDataSource
@@ -50,4 +52,9 @@ interface DataSourceModule {
     fun bindXRefLocalDataSource(
         xRefLocalDataSourceImpl: XRefLocalDataSourceImpl,
     ): XRefLocalDataSource
+
+    @Binds
+    fun bindImageSearchRemoteDataSource(
+        imageSearchRemoteDataSourceImpl: ImageSearchRemoteDataSourceImpl,
+    ): ImageSearchRemoteDataSource
 }

--- a/data/src/main/java/com/wakeup/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/wakeup/data/di/NetworkModule.kt
@@ -5,6 +5,7 @@ import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFact
 import com.wakeup.data.BuildConfig
 import com.wakeup.data.network.response.WeatherContainerResponse
 import com.wakeup.data.network.response.WeatherResponse
+import com.wakeup.data.network.service.ImageSearchService
 import com.wakeup.data.network.service.PlaceSearchService
 import com.wakeup.data.network.service.WeatherService
 import com.wakeup.domain.model.WeatherType
@@ -94,21 +95,23 @@ object NetworkModule {
             val request = chain.request()
             val response = chain.proceed(request)
             val jsonString = response.body?.string() ?: ""
-            val json = Json{ ignoreUnknownKeys = true }
+            val json = Json { ignoreUnknownKeys = true }
             val result = json.decodeFromString<WeatherContainerResponse>(jsonString)
             val weather = result.weathers.first()
             val type = getWeatherTypeById(weather.id)
             val main = result.main
             response.newBuilder()
                 .message(response.message)
-                .body(Json.encodeToString(
-                    WeatherResponse(
-                        weather.id,
-                        type,
-                        weather.icon,
-                        main.temperature
-                    )
-                ).toResponseBody())
+                .body(
+                    Json.encodeToString(
+                        WeatherResponse(
+                            weather.id,
+                            type,
+                            weather.icon,
+                            main.temperature
+                        )
+                    ).toResponseBody()
+                )
                 .build()
         }
     }
@@ -187,5 +190,11 @@ object NetworkModule {
     @Singleton
     fun provideWeatherService(@Named("Weather") retrofit: Retrofit): WeatherService {
         return retrofit.create(WeatherService::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideImageSearchService(@Named("Kakao") retrofit: Retrofit): ImageSearchService {
+        return retrofit.create(ImageSearchService::class.java)
     }
 }

--- a/data/src/main/java/com/wakeup/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/wakeup/data/di/RepositoryModule.kt
@@ -1,17 +1,19 @@
 package com.wakeup.data.di
 
 import com.wakeup.data.repository.GlobeRepositoryImpl
+import com.wakeup.data.repository.ImageSearchRepositoryImpl
 import com.wakeup.data.repository.MomentRepositoryImpl
 import com.wakeup.data.repository.PictureRepositoryImpl
 import com.wakeup.data.repository.PlaceSearchRepositoryImpl
+import com.wakeup.data.repository.RelationRepositoryImpl
 import com.wakeup.data.repository.WeatherRepositoryImpl
 import com.wakeup.domain.repository.GlobeRepository
+import com.wakeup.domain.repository.ImageSearchRepository
 import com.wakeup.domain.repository.MomentRepository
 import com.wakeup.domain.repository.PictureRepository
 import com.wakeup.domain.repository.PlaceSearchRepository
-import com.wakeup.domain.repository.WeatherRepository
-import com.wakeup.data.repository.RelationRepositoryImpl
 import com.wakeup.domain.repository.RelationRepository
+import com.wakeup.domain.repository.WeatherRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -50,4 +52,9 @@ interface RepositoryModule {
     fun bindRefRepository(
         refRepositoryImpl: RelationRepositoryImpl,
     ): RelationRepository
+
+    @Binds
+    fun bindImageSearchRepository(
+        imageSearchRepositoryImpl: ImageSearchRepositoryImpl,
+    ): ImageSearchRepository
 }

--- a/data/src/main/java/com/wakeup/data/network/mapper/ImageSearchResponseMapper.kt
+++ b/data/src/main/java/com/wakeup/data/network/mapper/ImageSearchResponseMapper.kt
@@ -1,0 +1,10 @@
+package com.wakeup.data.network.mapper
+
+import com.wakeup.data.network.response.ImageSearchResponseItem
+import com.wakeup.domain.model.Picture
+
+fun ImageSearchResponseItem.toDomain(): Picture {
+    return Picture(
+        path = thumbnailUrl,
+    )
+}

--- a/data/src/main/java/com/wakeup/data/network/response/ImageSearchResponse.kt
+++ b/data/src/main/java/com/wakeup/data/network/response/ImageSearchResponse.kt
@@ -1,0 +1,16 @@
+package com.wakeup.data.network.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+data class ImageSearchResponse(
+    val documents: List<ImageSearchResponseItem>,
+)
+
+@Serializable
+data class ImageSearchResponseItem(
+    @SerialName("thumbnail_url") val thumbnailUrl: String,
+    @SerialName("image_url") val imageUrl: String,
+)

--- a/data/src/main/java/com/wakeup/data/network/service/ImageSearchService.kt
+++ b/data/src/main/java/com/wakeup/data/network/service/ImageSearchService.kt
@@ -1,0 +1,14 @@
+package com.wakeup.data.network.service
+
+import com.wakeup.data.network.response.ImageSearchResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface ImageSearchService {
+
+    @GET("/v2/search/image")
+    suspend fun getImages(
+        @Query("query") keyword: String,
+        @Query("size") size: Int = 1,
+    ): ImageSearchResponse
+}

--- a/data/src/main/java/com/wakeup/data/repository/ImageSearchRepositoryImpl.kt
+++ b/data/src/main/java/com/wakeup/data/repository/ImageSearchRepositoryImpl.kt
@@ -1,0 +1,17 @@
+package com.wakeup.data.repository
+
+import com.wakeup.data.network.mapper.toDomain
+import com.wakeup.data.source.remote.imageSearch.ImageSearchRemoteDataSource
+import com.wakeup.domain.model.Picture
+import com.wakeup.domain.repository.ImageSearchRepository
+import javax.inject.Inject
+
+class ImageSearchRepositoryImpl @Inject constructor(
+    private val imageSearchRemoteDataSource: ImageSearchRemoteDataSource
+) : ImageSearchRepository {
+    override suspend fun search(keyword: String): Result<Picture> {
+        return imageSearchRemoteDataSource.search(keyword).mapCatching {
+            it.toDomain()
+        }
+    }
+}

--- a/data/src/main/java/com/wakeup/data/source/remote/imageSearch/ImageSearchRemoteDataSource.kt
+++ b/data/src/main/java/com/wakeup/data/source/remote/imageSearch/ImageSearchRemoteDataSource.kt
@@ -1,0 +1,8 @@
+package com.wakeup.data.source.remote.imageSearch
+
+import com.wakeup.data.network.response.ImageSearchResponseItem
+
+interface ImageSearchRemoteDataSource {
+
+    suspend fun search(keyword: String): Result<ImageSearchResponseItem>
+}

--- a/data/src/main/java/com/wakeup/data/source/remote/imageSearch/ImageSearchRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/wakeup/data/source/remote/imageSearch/ImageSearchRemoteDataSourceImpl.kt
@@ -1,0 +1,16 @@
+package com.wakeup.data.source.remote.imageSearch
+
+import com.wakeup.data.network.response.ImageSearchResponseItem
+import com.wakeup.data.network.service.ImageSearchService
+import javax.inject.Inject
+
+class ImageSearchRemoteDataSourceImpl @Inject constructor(
+    private val imageSearchService: ImageSearchService
+) : ImageSearchRemoteDataSource {
+
+    override suspend fun search(keyword: String): Result<ImageSearchResponseItem> {
+        return Result.runCatching {
+            imageSearchService.getImages(keyword).documents.first()
+        }
+    }
+}

--- a/domain/src/main/java/com/wakeup/domain/model/Place.kt
+++ b/domain/src/main/java/com/wakeup/domain/model/Place.kt
@@ -4,5 +4,6 @@ data class Place(
     val mainAddress: String,
     val detailAddress: String,
     val placeUrl: String? = null,
+    val placeImageUrl: String? = null,
     val location: Location,
 )

--- a/domain/src/main/java/com/wakeup/domain/repository/ImageSearchRepository.kt
+++ b/domain/src/main/java/com/wakeup/domain/repository/ImageSearchRepository.kt
@@ -1,0 +1,7 @@
+package com.wakeup.domain.repository
+
+import com.wakeup.domain.model.Picture
+
+interface ImageSearchRepository {
+    suspend fun search(keyword: String): Result<Picture>
+}

--- a/domain/src/main/java/com/wakeup/domain/usecase/search/SearchImageUseCase.kt
+++ b/domain/src/main/java/com/wakeup/domain/usecase/search/SearchImageUseCase.kt
@@ -1,0 +1,13 @@
+package com.wakeup.domain.usecase.search
+
+import com.wakeup.domain.model.Picture
+import com.wakeup.domain.repository.ImageSearchRepository
+import javax.inject.Inject
+
+class SearchImageUseCase @Inject constructor(
+    private val imageSearchRepository: ImageSearchRepository
+) {
+    suspend operator fun invoke(keyword: String): Result<Picture> {
+        return imageSearchRepository.search(keyword)
+    }
+}

--- a/domain/src/main/java/com/wakeup/domain/usecase/search/SearchPlaceUseCase.kt
+++ b/domain/src/main/java/com/wakeup/domain/usecase/search/SearchPlaceUseCase.kt
@@ -1,4 +1,4 @@
-package com.wakeup.domain.usecase.place
+package com.wakeup.domain.usecase.search
 
 import com.wakeup.domain.model.Place
 import com.wakeup.domain.repository.PlaceSearchRepository

--- a/presentation/src/main/java/com/wakeup/presentation/extension/Extensions.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/extension/Extensions.kt
@@ -2,7 +2,6 @@ package com.wakeup.presentation.extension
 
 import android.animation.Animator.AnimatorListener
 import android.animation.ObjectAnimator
-import android.app.Activity
 import android.content.Context
 import android.content.res.Resources
 import android.graphics.Bitmap
@@ -87,13 +86,15 @@ fun View.showSnackbar(text: String) {
     Snackbar.make(this, text, Snackbar.LENGTH_SHORT).show()
 }
 
-fun Activity.setStatusBarTransparent() {
-    window.setFlags(
+fun Fragment.setStatusBarTransparent() {
+    this.requireActivity().window.setFlags(
         WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
         WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
     )
 }
 
-fun Activity.resetStatusBarTransparent() {
-    window.clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
+fun Fragment.resetStatusBarTransparent() {
+    this.requireActivity().window.clearFlags(
+        WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
+    )
 }

--- a/presentation/src/main/java/com/wakeup/presentation/extension/Extensions.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/extension/Extensions.kt
@@ -2,6 +2,7 @@ package com.wakeup.presentation.extension
 
 import android.animation.Animator.AnimatorListener
 import android.animation.ObjectAnimator
+import android.app.Activity
 import android.content.Context
 import android.content.res.Resources
 import android.graphics.Bitmap
@@ -9,6 +10,7 @@ import android.graphics.Canvas
 import android.os.Build
 import android.util.TypedValue
 import android.view.View
+import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import androidx.core.content.ContextCompat
@@ -83,4 +85,15 @@ fun getBitMapFromVectorDrawable(context: Context, drawableId: Int): Bitmap {
 
 fun View.showSnackbar(text: String) {
     Snackbar.make(this, text, Snackbar.LENGTH_SHORT).show()
+}
+
+fun Activity.setStatusBarTransparent() {
+    window.setFlags(
+        WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+        WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
+    )
+}
+
+fun Activity.resetStatusBarTransparent() {
+    window.clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
 }

--- a/presentation/src/main/java/com/wakeup/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/MainActivity.kt
@@ -47,7 +47,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun loadData() {
-        binding.root.viewTreeObserver.addOnPreDrawListener(object : ViewTreeObserver.OnPreDrawListener{
+        binding.root.viewTreeObserver.addOnPreDrawListener(object :
+            ViewTreeObserver.OnPreDrawListener {
             override fun onPreDraw(): Boolean {
                 return if (viewModel.isReady.value) {
                     Timber.d("Success load data")
@@ -110,7 +111,7 @@ class MainActivity : AppCompatActivity() {
         navController.addOnDestinationChangedListener { _, destination, _ ->
             val isTopDest = appBarConfiguration.topLevelDestinations.contains(destination.id)
             binding.bottomAppBar.isVisible = isTopDest
-            binding.fab.isVisible = isTopDest
+            if (isTopDest) binding.fab.show() else binding.fab.hide()
         }
     }
 

--- a/presentation/src/main/java/com/wakeup/presentation/ui/addmoment/PlaceCheckViewModel.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/addmoment/PlaceCheckViewModel.kt
@@ -1,11 +1,19 @@
 package com.wakeup.presentation.ui.addmoment
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wakeup.domain.usecase.search.SearchImageUseCase
 import com.wakeup.presentation.model.PlaceModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class PlaceCheckViewModel : ViewModel() {
+@HiltViewModel
+class PlaceCheckViewModel @Inject constructor(
+    private val searchImageUseCase: SearchImageUseCase,
+) : ViewModel() {
 
     private val _place = MutableStateFlow<PlaceModel?>(null)
     val place = _place.asStateFlow()
@@ -15,11 +23,13 @@ class PlaceCheckViewModel : ViewModel() {
 
     fun setPlace(place: PlaceModel) {
         _place.value = place
+        setImageUrl(place.detailAddress + place.mainAddress)
     }
 
-    fun setImageUrl(imageUrl: String?) {
-        imageUrl?.let {
-            _imageUrl.value = "https:$it"
+    private fun setImageUrl(address: String) {
+        viewModelScope.launch {
+            _imageUrl.value =
+                searchImageUseCase(address).getOrNull()?.path
         }
     }
 }

--- a/presentation/src/main/java/com/wakeup/presentation/ui/addmoment/PlaceSearchViewModel.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/addmoment/PlaceSearchViewModel.kt
@@ -2,7 +2,7 @@ package com.wakeup.presentation.ui.addmoment
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wakeup.domain.usecase.place.SearchPlaceUseCase
+import com.wakeup.domain.usecase.search.SearchPlaceUseCase
 import com.wakeup.presentation.mapper.toPresentation
 import com.wakeup.presentation.model.PlaceModel
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/presentation/src/main/java/com/wakeup/presentation/ui/home/HomeFragment.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/home/HomeFragment.kt
@@ -2,10 +2,6 @@ package com.wakeup.presentation.ui.home
 
 import android.Manifest
 import android.annotation.SuppressLint
-import android.content.BroadcastReceiver
-import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.location.Location
 import android.os.Bundle
@@ -22,7 +18,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
-import com.wakeup.domain.model.SortType
 import com.wakeup.presentation.R
 import com.wakeup.presentation.databinding.FragmentHomeBinding
 import com.wakeup.presentation.extension.hideKeyboard
@@ -34,9 +29,7 @@ import com.wakeup.presentation.ui.MainViewModel
 import com.wakeup.presentation.ui.UiState
 import com.wakeup.presentation.ui.home.map.MapFragment
 import com.wakeup.presentation.ui.home.sheet.BottomSheetFragment
-import com.wakeup.presentation.util.UPDATE_MOMENTS_KEY
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -68,7 +61,7 @@ class HomeFragment : Fragment() {
         binding.lifecycleOwner = viewLifecycleOwner
         binding.viewModel = viewModel
 
-        requireActivity().setStatusBarTransparent()
+        setStatusBarTransparent()
         return binding.root
     }
 
@@ -164,8 +157,8 @@ class HomeFragment : Fragment() {
     }
 
     override fun onDestroyView() {
+        resetStatusBarTransparent()
         binding.unbind()
-        requireActivity().resetStatusBarTransparent()
         super.onDestroyView()
     }
 }

--- a/presentation/src/main/java/com/wakeup/presentation/ui/home/HomeFragment.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/ui/home/HomeFragment.kt
@@ -22,6 +22,8 @@ import com.wakeup.domain.model.SortType
 import com.wakeup.presentation.R
 import com.wakeup.presentation.databinding.FragmentHomeBinding
 import com.wakeup.presentation.extension.hideKeyboard
+import com.wakeup.presentation.extension.resetStatusBarTransparent
+import com.wakeup.presentation.extension.setStatusBarTransparent
 import com.wakeup.presentation.model.LocationModel
 import com.wakeup.presentation.ui.MainActivity
 import com.wakeup.presentation.ui.home.map.MapFragment
@@ -54,6 +56,8 @@ class HomeFragment : Fragment() {
         binding = FragmentHomeBinding.inflate(inflater, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
         binding.viewModel = viewModel
+
+        requireActivity().setStatusBarTransparent()
         return binding.root
     }
 
@@ -142,6 +146,7 @@ class HomeFragment : Fragment() {
 
     override fun onDestroyView() {
         binding.unbind()
+        requireActivity().resetStatusBarTransparent()
         super.onDestroyView()
     }
 }

--- a/presentation/src/main/res/animator/nav_default_enter_anim.xml
+++ b/presentation/src/main/res/animator/nav_default_enter_anim.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+
+</set>

--- a/presentation/src/main/res/animator/nav_default_exit_anim.xml
+++ b/presentation/src/main/res/animator/nav_default_exit_anim.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+
+</set>

--- a/presentation/src/main/res/animator/nav_default_pop_enter_anim.xml
+++ b/presentation/src/main/res/animator/nav_default_pop_enter_anim.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+
+</set>

--- a/presentation/src/main/res/animator/nav_default_pop_exit_anim.xml
+++ b/presentation/src/main/res/animator/nav_default_pop_exit_anim.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+
+</set>

--- a/presentation/src/main/res/layout/fragment_home.xml
+++ b/presentation/src/main/res/layout/fragment_home.xml
@@ -18,8 +18,9 @@
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/cv_search"
             android:layout_width="0dp"
+            android:layout_marginTop="@dimen/normal_250"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/normal_100"
+            android:layout_marginHorizontal="@dimen/normal_100"
             app:cardCornerRadius="@dimen/small_100"
             app:cardElevation="@dimen/small_100"
             app:layout_constraintEnd_toStartOf="@id/cv_weather"
@@ -74,10 +75,10 @@
 
                 <ImageView
                     android:id="@+id/iv_weather_icon"
-                    app:imageFromUrl="@{viewModel.weather.iconUrl}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="-8dp"
+                    app:imageFromUrl="@{viewModel.weather.iconUrl}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />

--- a/presentation/src/main/res/layout/fragment_map.xml
+++ b/presentation/src/main/res/layout/fragment_map.xml
@@ -20,58 +20,58 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
 
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/cl_map_controls_container"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_map_controls_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start|bottom"
+            android:layout_marginHorizontal="@dimen/normal_100"
+            android:layout_marginBottom="@dimen/map_moment_preview_margin">
+
+            <com.naver.maps.map.widget.LocationButtonView
+                android:id="@+id/lbv_location"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toTopOf="@id/lv_logo"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_bias="1"
+                app:layout_constraintVertical_chainStyle="packed" />
+
+            <com.naver.maps.map.widget.ScaleBarView
+                android:id="@+id/sbv_scale"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/normal_100"
+                android:layout_marginTop="@dimen/small_100"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0"
+                app:layout_constraintStart_toEndOf="@id/lv_logo"
+                app:layout_constraintTop_toBottomOf="@id/lbv_location" />
+
+            <com.naver.maps.map.widget.LogoView
+                android:id="@+id/lv_logo"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/small_100"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="@id/lbv_location"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/lbv_location"
+                app:layout_constraintVertical_bias="0" />
+
+            <include
+                android:id="@+id/moment_preview"
+                layout="@layout/item_moment_preview"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="start|bottom"
-                android:layout_marginHorizontal="@dimen/normal_100"
-                android:layout_marginBottom="@dimen/map_moment_preview_margin">
-
-                <com.naver.maps.map.widget.LocationButtonView
-                    android:id="@+id/lbv_location"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintBottom_toTopOf="@id/lv_logo"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintHorizontal_bias="0"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintVertical_bias="1"
-                    app:layout_constraintVertical_chainStyle="packed" />
-
-                <com.naver.maps.map.widget.ScaleBarView
-                    android:id="@+id/sbv_scale"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/normal_100"
-                    android:layout_marginTop="@dimen/small_100"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintHorizontal_bias="0"
-                    app:layout_constraintStart_toEndOf="@id/lv_logo"
-                    app:layout_constraintTop_toBottomOf="@id/lbv_location" />
-
-                <com.naver.maps.map.widget.LogoView
-                    android:id="@+id/lv_logo"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/small_100"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="@id/lbv_location"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/lbv_location"
-                    app:layout_constraintVertical_bias="0" />
-
-                <include
-                    android:id="@+id/moment_preview"
-                    layout="@layout/item_moment_preview"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:momentModel="@{momentModel}" />
-            </androidx.constraintlayout.widget.ConstraintLayout>
-        </FrameLayout>
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:momentModel="@{momentModel}" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </FrameLayout>
 
 </layout>

--- a/presentation/src/main/res/layout/layout_drawer.xml
+++ b/presentation/src/main/res/layout/layout_drawer.xml
@@ -6,7 +6,8 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"
-        android:padding="@dimen/large_125">
+        android:paddingTop="@dimen/large_200"
+        android:paddingHorizontal="@dimen/large_125">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
@@ -36,9 +37,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="@dimen/small_50"
-                app:layout_constraintTop_toTopOf="@id/tv_alarm"
                 app:layout_constraintBottom_toBottomOf="@id/tv_alarm"
-                app:layout_constraintEnd_toEndOf="parent" />
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/tv_alarm" />
 
             <TextView
                 android:id="@+id/tv_theme"
@@ -56,9 +57,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@null"
-                app:layout_constraintTop_toTopOf="@id/tv_theme"
                 app:layout_constraintBottom_toBottomOf="@id/tv_theme"
-                app:layout_constraintEnd_toEndOf="parent" />
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/tv_theme" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/presentation/src/main/res/menu/menu_bottom_nav.xml
+++ b/presentation/src/main/res/menu/menu_bottom_nav.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
         android:id="@+id/home_fragment"
@@ -9,6 +8,7 @@
 
     <item
         android:id="@+id/add"
+        android:enabled="false"
         android:title="" />
 
     <item

--- a/presentation/src/main/res/values-night/styles.xml
+++ b/presentation/src/main/res/values-night/styles.xml
@@ -42,6 +42,6 @@
 
     <style name="TextAppearance.Mogle.Temperature" parent="TextAppearance.MaterialComponents.Caption">
         <item name="android:textSize">10sp</item>
-        <item name="android:textColor">@color/black</item>
+        <item name="android:textColor">@color/white</item>
     </style>
 </resources>


### PR DESCRIPTION
### 👨‍🔧 개요
- 장소 이미지 크롤링을 제거했습니다.
- 지도의 StatusBar를 투명처리 했습니다.
- 여러 버그를 해결했습니다.


### 📝 작업 내용
- 크롤링을 제거하고,  검색 API 로 장소 이미지를 가져옵니다.
- 홈화면에 들어오면 StatusBar 투명, 다른 화면 이동하면, 투명 제거
- 모먼트 남기기를 갔다오면 FAB 굴곡이 없어지는 버그 해결
- 홈화면에서 글로브화면 UI 튀는 현상을 해결
- FAB 아래 터치를 불가능하도록 수정

### 📱 수정된 동작화면

https://user-images.githubusercontent.com/80373033/206859647-1c3c629e-074c-4173-a017-58e9ce41e1fb.mp4


### 📢 특이 사항
> 집중적으로 봐야하거나, 추가 및 특이 사항

구웃👍

버그 해결 과정은 이슈 공유에 작성해두었습니다!