### PR TITLE
테마 변경후 같은 Dialog 를 다시 띄우면 앱이 터지거나 이전 테마로 뜨는 현상 해결

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <application
         android:name=".MogleApplication"
-        android:allowBackup="false"
+        android:allowBackup="true"
         android:icon="@mipmap/ic_launcher_mogle"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_mogle_round"

--- a/presentation/src/main/java/com/wakeup/presentation/lib/dialog/EditDialog.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/lib/dialog/EditDialog.kt
@@ -32,7 +32,7 @@ class EditDialog private constructor(context: Context) :
          */
         fun with(context: Context, layoutId: Int, editTextId: Int): EditDialog {
             val instance = INSTANCE
-            if (instance?.baseLayoutId == layoutId) return instance
+            if (instance?.context == context && instance.baseLayoutId == layoutId) return instance
 
             INSTANCE = EditDialog(context).apply {
                 builder = AlertDialog.Builder(context)

--- a/presentation/src/main/java/com/wakeup/presentation/lib/dialog/EditDialog.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/lib/dialog/EditDialog.kt
@@ -32,7 +32,10 @@ class EditDialog private constructor(context: Context) :
          */
         fun with(context: Context, layoutId: Int, editTextId: Int): EditDialog {
             val instance = INSTANCE
-            if (instance?.context == context && instance.baseLayoutId == layoutId) return instance
+            if (instance?.context == context && instance.baseLayoutId == layoutId) {
+                instance.editText.text.clear()
+                return instance
+            }
 
             INSTANCE = EditDialog(context).apply {
                 builder = AlertDialog.Builder(context)

--- a/presentation/src/main/java/com/wakeup/presentation/lib/dialog/NormalDialog.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/lib/dialog/NormalDialog.kt
@@ -25,7 +25,7 @@ class NormalDialog private constructor(context: Context) :
          */
         fun with(context: Context, layoutId: Int): NormalDialog {
             val instance = INSTANCE
-            if (instance?.baseLayoutId == layoutId) return instance
+            if (instance?.context == context && instance.baseLayoutId == layoutId) return instance
 
             INSTANCE = NormalDialog(context).apply {
                 builder = AlertDialog.Builder(context)

--- a/presentation/src/main/java/com/wakeup/presentation/lib/dialog/PictureDialog.kt
+++ b/presentation/src/main/java/com/wakeup/presentation/lib/dialog/PictureDialog.kt
@@ -37,7 +37,7 @@ class PictureDialog private constructor(context: Context) :
          */
         fun with(context: Context, layoutId: Int, imageViewId: Int): PictureDialog {
             val instance = INSTANCE
-            if (instance?.baseLayoutId == layoutId) return instance
+            if (instance?.context == context && instance.baseLayoutId == layoutId) return instance
 
             INSTANCE = PictureDialog(context).apply {
                 builder = AlertDialog.Builder(context)


### PR DESCRIPTION
### 👨‍🔧 개요

테마가 변경됨에 따라 Dialog 오작동

### 📝 작업 내용

INSTNACE 를 사용해, 중복 생성을 막고 있었는데!!!
theme 을 변경하면서 context 변경까진 신경쓰진 못했다!!!!

### 📱 수정후 동작 화면

https://user-images.githubusercontent.com/80373033/207521686-83f0df5f-96df-4b94-853e-e64ab51115f4.mp4


### 📢 특이 사항
> 집중적으로 봐야하거나, 추가 및 특이 사항

구웃